### PR TITLE
Fixing a small typo in the parameters (collectd_use_entry_points)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class bucky(
   $collectd_port               = $bucky::params::collectd_port,
   $collectd_types              = $bucky::params::collectd_types,
   $collectd_converters         = $bucky::params::collectd_converters,
-  $collectd_use_entry_points   = $bucky::params::collectd_entry_points,
+  $collectd_use_entry_points   = $bucky::params::collectd_use_entry_points,
   $grahite_host                = $bucky::params::graphite_host,
   $graphite_port               = $bucky::params::graphite_port,
   $graphite_max_reconnect      = $bucky::params::graphite_max_reconnect,


### PR DESCRIPTION
Here's the fix for this small typo.
