### PR TITLE
Fixed statsd_flush_time typo in params.pp and bucky.conf.erb

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class bucky::params {
   $statsd_enabled   = false
   $statsd_ip        = '127.0.0.1'
   $statsd_port      = '8125'
-  $statsd_flushtime = '10.0'
+  $statsd_flush_time = '10.0'
 
   # graphite
   $graphite_host               = '127.0.0.1'

--- a/templates/etc/bucky/bucky.conf.erb
+++ b/templates/etc/bucky/bucky.conf.erb
@@ -57,7 +57,7 @@ statsd_port = <%= scope.lookupvar('bucky::statsd_port') %>
 statsd_enabled = True
 
 # How often stats should be flushed to Graphite.
-statsd_flush_time = <%= scope.lookupvar('bucky::statsd_flushtime') %>
+statsd_flush_time = <%= scope.lookupvar('bucky::statsd_flush_time') %>
 <%- else -%>
 statsd_enabled = False
 <%- end -%>


### PR DESCRIPTION
Minor fix to statsd_flush_time in params and config template file. 

First ever pull request. (Yay!)
